### PR TITLE
fix Mongoose: mpromise deprecation waring

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "bugs": "http://github.com/mblarsen/mongoose-hidden/issues",
   "dependencies": {
+    "bluebird": "^3.4.6",
     "debug": "^2.2.0",
     "object-assign": "^4.0.1"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,7 @@ describe("mongoose-hidden", function () {
   };
 
   before(function (done) {
+    mongoose.Promise = require('bluebird');
     mongoose.connect('mongodb://localhost/mongoose-hidden', function(err) {
       if (err) {
         console.error('MongoDB: ' + err.message);


### PR DESCRIPTION
DeprecationWarning: Mongoose: mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead: http://mongoosejs.com/docs/promises.html