### PR TITLE
Support subdocument schema transformations

### DIFF
--- a/lib/mongoose-hidden.js
+++ b/lib/mongoose-hidden.js
@@ -287,9 +287,6 @@ module.exports = function (defaults) {
 
     let transformer = function (target, prevTransform) {
       return function (doc, transformed, opt) {
-        if (typeof doc.ownerDocument === 'function') {
-          return transformed
-        }
 
         log(transformed)
 


### PR DESCRIPTION
The removed block of code was preventing transformations on subdocuments defined as Schemas.