### PR TITLE
Do not create undefined versions of properties not present in origina…

### DIFF
--- a/lib/mongoose-hidden.js
+++ b/lib/mongoose-hidden.js
@@ -264,8 +264,12 @@ module.exports = function (defaults) {
             log('%s: hiding "%s"', target, pathname)
             mpath.unset(pathname, finalTransform)
           } else {
-            log('%s: copy "%s"', target, pathname)
-            setPath(finalTransform, pathname, mpath.get(pathname, transformed))
+            // Do not create properties with undefined value for paths not present in original transformed object
+            let value = mpath.get(pathname, transformed);
+            if (value !== undefined) {
+              log('%s: copy "%s"', target, pathname)
+              setPath(finalTransform, pathname, value)
+            }
           }
         })
 

--- a/lib/mongoose-hidden.js
+++ b/lib/mongoose-hidden.js
@@ -264,9 +264,8 @@ module.exports = function (defaults) {
             log('%s: hiding "%s"', target, pathname)
             mpath.unset(pathname, finalTransform)
           } else {
-            // Do not create properties with undefined value for paths not present in original transformed object
-            let value = mpath.get(pathname, transformed);
-            if (value !== undefined) {
+            let value = mpath.get(pathname, transformed)
+            if (typeof value !== 'undefined') {
               log('%s: copy "%s"', target, pathname)
               setPath(finalTransform, pathname, value)
             }


### PR DESCRIPTION
Version 1.5 is not compatible with 1.4. It erroneously adds properties with undefined value for paths not present in original transformed object. 

Example:
with schema where fields are optional
  { field1: Number, field2: String, field3: String})
document before transform
  { field1: 123, field3: 'abc' }
becomes after transform by mongoose-hidden
  { field1: 123, field2: undefined, field3: 'abc' }

The pull request includes a fix for this